### PR TITLE
Add Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+jekyll:
+  image: jekyll/jekyll
+  command: jekyll serve --watch --incremental
+  ports:
+    - 4000:4000
+  volumes:
+    - .:/srv/jekyll


### PR DESCRIPTION
This allows people who have Docker Compose installed to run the
site locally by running `docker-compose up`, without having to
install Ruby globally.