### PR TITLE
Update 03.1_quickstart-creation.md

### DIFF
--- a/pages/implement/apps/vocabularies/03.1_quickstart-creation.md
+++ b/pages/implement/apps/vocabularies/03.1_quickstart-creation.md
@@ -8,12 +8,12 @@ Let us build a very simple vocabulary describing [obelisks](https://en.wikipedia
 
 ## From plain English to a graphical representation
 
-Let's start by stating in English what we want to put in our vocabulary:
+Let's start by stating in English what we'd like to put in our vocabulary:
 - An <u>__obelisk__</u> is <u>__owned by__</u> a <u>__person__</u>.
 - An <u>__obelisk__</u> is <u>__built by__</u> a <u>__sculptor__</u>.
 - An <u>__obelisk__</u> has a <u>__height__</u>, which is a numerical value.
 
-The underlined elements of these sentences are going to be the terms of our vocabulary. We can identify two types of terms: the things that we talk about (e.g. <u>obelisk</u>), and their properties (e.g. <u>built by</u>). Let's make a graphical representation of that, by putting the things in bubbles and the properties in squares:
+The underlined elements of these sentences are going to be the 'terms' in our vocabulary. We can identify two types of terms: the things that we talk about (e.g. <u>__obelisk__</u> or <u>__sculptor__</u>), and their properties (e.g. <u>__built by__</u> or <u>__height__</u>). Let's make a graphical representation of that, by putting the things in bubbles and the properties in squares:
 
 ![The obelisk vocabulary]({{site.baseurl}}/assets/img/tutorials/vocabularies/obelisk_vocab_1.png)
 
@@ -26,24 +26,24 @@ RDF is the language that is used to build vocabularies for Linked Data. In RDF, 
 - An <u>http://w3id.org/obelisk/ns/Obelisk</u> is <u>http://w3id.org/obelisk/ns/builtBy</u> a <u>http://w3id.org/obelisk/ns/Sculptor</u>.
 - An <u>http://w3id.org/obelisk/ns/Obelisk</u> has a <u>http://w3id.org/obelisk/ns/height</u>, which is a numerical value.
 
-Identifiers are getting unpleasant to read very fast when they are IRI, so RDF introduces the notion of prefix: from now on, `obelisk:` will stand for `http://w3id.org/obelisk/ns/`, which means our vocabulary now looks like:
+Identifiers quickly become unpleasant to read when they are IRIs, so RDF introduces the notion of prefixes: from now on, `obelisk:` will stand for `http://w3id.org/obelisk/ns/`, which means our vocabulary now looks like:
 - An [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) is [obelisk:ownedBy](http://w3id.org/obelisk/ns/ownedBy) a [obelisk:Person](http://w3id.org/obelisk/ns/Person).
 - An [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) is [obelisk:builtBy](http://w3id.org/obelisk/ns/builtBy) a [obelisk:Sculptor](http://w3id.org/obelisk/ns/Sculptor).
 - An [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) has a [obelisk:height](http://w3id.org/obelisk/ns/height), which is a numerical value.
 
 ### Defining classes of things
 
-In RDF, the general things that we can talk about are called __classes__. Everything that went in a bubble in our first schema is therefore a class, so we could add to our vocabulary:
-- [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) is a class.
-- [obelisk:Person](http://w3id.org/obelisk/ns/Person) is a class.
-- [obelisk:Sculptor](http://w3id.org/obelisk/ns/Sculptor) is a class.
+In RDF, the general things that we can talk about are called __Classes__. Everything that went in a bubble in our first schema is therefore a Class, so we could add the following to our vocabulary:
+- [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) is a Class.
+- [obelisk:Person](http://w3id.org/obelisk/ns/Person) is a Class.
+- [obelisk:Sculptor](http://w3id.org/obelisk/ns/Sculptor) is a Class.
 
-If we look at these sentences, they are structured exactly like the ones from the rest of the vocabulary. Let us underline the important bits in the same way:
+If we look at these sentences, they are structured exactly like the ones from the rest of our vocabulary. Let us underline the important bits in the same way:
 - [obelisk:Obelisk](http://w3id.org/obelisk/ns/Obelisk) [is a](???) [class](???).
 - [obelisk:Person](http://w3id.org/obelisk/ns/Person) [is a](???) [class](???).
 - [obelisk:Sculptor](http://w3id.org/obelisk/ns/Sculptor) [is a](???) [class](???).
 
-What we need now are IRI for the "[is a](???)" property and the "[class](???)" class. Fortunately, these are defined in the RDF and RDFS vocabularies: "[is a](???)" is defined by [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), and "[class](???)" by [rdfs:Class](http://www.w3.org/2000/01/rdf-schema#Class). Therefore, we could write:
+What we need now are IRI for the "[is a](???)" property and the "[Class](???)" Class. Fortunately, these are defined in the RDF and RDFS vocabularies: "[is a](???)" is defined by [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), and "[class](???)" by [rdfs:Class](http://www.w3.org/2000/01/rdf-schema#Class). Therefore, we could write:
 
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
@@ -55,21 +55,21 @@ obelisk:Person rdf:type rdfs:Class .
 obelisk:Sculptor rdf:type rdfs:Class .
 ```
 
-And congratulation, you just read your first snippet of RDF! This RDF syntax is called the Turtle syntax, other exist but we don't need to go over them in this tutorial.
+And congratulations, you've just created your first snippet of RDF! This particular RDF syntax is called Turtle. Others exist but we don't need to go over them in this tutorial.
 
 ### Defining properties
 
-The properties of things in RDF are called properties (how convenient). Therefore, following what we did for classes, we might write:
+The properties of things in RDF are called properties (how convenient). Therefore, following what we did for Classes, we might write:
 - [obelisk:ownedBy](http://w3id.org/obelisk/ns/ownedBy) [is a](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 - [obelisk:builtBy](http://w3id.org/obelisk/ns/builtBy) [is a](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 - [obelisk:height](http://w3id.org/obelisk/ns/height) [is a](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 
-We already know that [is a](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) is identified by the IRI [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), so we can go ahead and change that into:
+We already know that [is a](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) is identified by the IRI [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), so we can now go ahead and change that into:
 - [obelisk:ownedBy](http://w3id.org/obelisk/ns/ownedBy) [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 - [obelisk:builtBy](http://w3id.org/obelisk/ns/builtBy) [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 - [obelisk:height](http://w3id.org/obelisk/ns/height) [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type) [property](???).
 
-However, we can see on the graphical representation we made earlier that there are two kind of properties: the one connecting things (bubbles) together, and the ones attaching a value to a thing. These are actually two different classes of properties: the former are called [owl:ObjectProperty](http://www.w3.org/2002/07/owl#ObjectProperty), and the latter [owl:DataProperty](http://www.w3.org/2002/07/owl#DataProperty).
+However, as we can see on the graphical representation we made earlier, there are two kind of properties: the ones connecting things (i.e. bubbles) together, and the ones attaching a 'value' to a thing. These are actually two different Classes of properties: the former are called [owl:ObjectProperty](http://www.w3.org/2002/07/owl#ObjectProperty), and the latter [owl:DataProperty](http://www.w3.org/2002/07/owl#DataProperty).
 
 Which leads to our vocabulary looking like this:
 
@@ -88,7 +88,7 @@ obelisk:builtBy rdf:type owl:ObjectProperty .
 obelisk:height rdf:type owl:DataProperty .
 ```
 
-However, we can see in this current vocabulary that some information is missing compared to our initial schema: nowhere does it say that [`obelisk:ownedBy`](http://w3id.org/obelisk/ns/ownedBy) has something to do with [`obelisk:Obelisk`](http://w3id.org/obelisk/ns/Obelisk) and [`obelisk:Person`](http://w3id.org/obelisk/ns/Person) for instance. To do that, we need to introduce the notion of [rdfs:domain](http://www.w3.org/2000/01/rdf-schema#domain) and [rdfs:range](http://www.w3.org/2000/01/rdf-schema#range). Basically, these two specify the class of the things connected by a property: the [rdfs:domain](http://www.w3.org/2000/01/rdf-schema#domain) it the class of the thing the property is about, and the [rdfs:range](http://www.w3.org/2000/01/rdf-schema#range) is the class of the thing that the property points to. Therefore, we can add to our vocabulary:
+However, we can see in this current vocabulary that some information is still missing from our initial schema: nowhere does it say that [`obelisk:ownedBy`](http://w3id.org/obelisk/ns/ownedBy) has something to do with [`obelisk:Obelisk`](http://w3id.org/obelisk/ns/Obelisk) and [`obelisk:Person`](http://w3id.org/obelisk/ns/Person) for instance. To do that, we need to introduce the notion of [rdfs:domain](http://www.w3.org/2000/01/rdf-schema#domain) and [rdfs:range](http://www.w3.org/2000/01/rdf-schema#range). Basically, these two specify the class of the things connected by a property: the [rdfs:domain](http://www.w3.org/2000/01/rdf-schema#domain) it the class of the thing the property is about, and the [rdfs:range](http://www.w3.org/2000/01/rdf-schema#range) is the class of the thing that the property points to. Therefore, we can add to our vocabulary:
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -114,7 +114,7 @@ obelisk:height rdfs:domain obelisk:Obelisk .
 obelisk:height rdfs:range xsd:float .
 ```
 
-Here, we could point out that things are getting very verbose. Hopefully, the Turtle syntax allows to make things shorter by not repeating the thing that we talk about when adding multiple properties to it (e.g. `obelisk:ownedBy` in the next snippet):
+Here, we could point out that things are getting pretty verbose. Thankfully the Turtle syntax provides shortcuts to avoid repeating the thing that we talk about when adding multiple properties to it (e.g. `obelisk:ownedBy` in the next snippet):
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -144,7 +144,7 @@ obelisk:height rdf:type owl:DataProperty ;
 
 ### Connecting to other vocabularies
 
-Terms in vocabularies are identified by IRI, and it's not for decoration: it means that you can use the identifiers accross the whole Web. The cool thing about it is that it makes it really easy to reuse terms from remote vocabularies into your own. For instance, [`obelisk:Obelisk`](http://w3id.org/obelisk/ns/Obelisk) is quite a specific term, so it makes perfect sense to define it ourselves. What about [`obelisk:Person`](http://w3id.org/obelisk/ns/Person) ? Maybe there is a reference vocabulary out there that defines the concept of person... And if you pay a quick visit to [our list of well-known vocabularies](1-well-known), you will see that there is! For instance, [Friend of a Friend](http://xmlns.com/foaf/0.1/) (foaf for short) defines the term [foaf:Person](http://xmlns.com/foaf/0.1/Person), and it would make our vocabulary easier to integrate into any application if we just reused this term instead of defining our own. Therefore, our vocabulary could look more something like this:
+Terms in vocabularies are identified by IRI, and it's not for decoration: it means that you can use the identifiers across the entire Web. The cool thing about that is that it makes it really easy to reuse terms from remote vocabularies in your own vocabularies. For instance, [`obelisk:Obelisk`](http://w3id.org/obelisk/ns/Obelisk) is quite a specific term, so it makes perfect sense to define it ourselves. What about [`obelisk:Person`](http://w3id.org/obelisk/ns/Person) ? Maybe there is a reference vocabulary out there that defines the concept of person... And if you pay a quick visit to [our list of well-known vocabularies](1-well-known), you will see that indeed there is! For instance, [Friend of a Friend](http://xmlns.com/foaf/0.1/) (foaf for short) defines the term [foaf:Person](http://xmlns.com/foaf/0.1/Person), and it would make our vocabulary easier to integrate into any application if we just reused this term instead of defining our own. Therefore, our vocabulary could look more something like this:
 
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
@@ -171,7 +171,7 @@ obelisk:height rdf:type owl:DataProperty ;
     rdfs:range xsd:float .
 ```
 
-Moreover, let's say it: sculptors are people too! Therefore, the class we define and that is specific to our vocabulary is a specialization of a class defined elsewhere. Saying so is actually very easy, with the [rdfs:subClassOf](http://www.w3.org/2000/01/rdf-schema#subClassOf) property:
+Moreover, sculptors are people too! Therefore the class we define, and that is specific to our vocabulary, is a specialization of a class defined elsewhere. Saying so is actually very easy, with the [rdfs:subClassOf](http://www.w3.org/2000/01/rdf-schema#subClassOf) property:
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -202,7 +202,7 @@ obelisk:height rdf:type owl:DataProperty ;
 
 ### Using labels and comments
 
-So far, all we have manipulated are identifiers that are primarily made for machines. Even if it is not recommanded, the IRIs need not have a readable meaning, and the following would technically be an equivalent vocabulary:
+So far, all we have manipulated here are identifiers that are primarily made for machines. Although it is certainly not recommended, the IRIs themselves do not need to be meaningful to humans at all. For example, the following would technically be an equivalent vocabulary:
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -228,7 +228,7 @@ obelisk:p003 rdf:type owl:DataProperty ;
     rdfs:domain obelisk:C001 ;
     rdfs:range xsd:float .
 ```
-Even if we don't want our vocabulary to look like this, the point that we are making here is that we now need to add to our terms descriptions for humans.To do so, we'll use the properties [`rdfs:label`](http://www.w3.org/2000/01/rdf-schema#) to add a human-readable version of the term identified by the IRI, and [`rdfs:comment`](http://www.w3.org/2000/01/rdf-schema#comment) to add a few sentences describing what is meant by the term in the context we use it. This could lead to something like this:
+Even if we don't want our vocabulary to look like this, the point we're making here is that we now need to add to our terms descriptions for humans. To do so we'll use the properties [`rdfs:label`](http://www.w3.org/2000/01/rdf-schema#) to add a human-readable label for the term identified by the IRI, and [`rdfs:comment`](http://www.w3.org/2000/01/rdf-schema#comment) to add a few sentences describing what is meant by the term in the context we use it. This could lead to something like this:
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -270,7 +270,7 @@ obelisk:height rdf:type owl:DataProperty ;
 
 ### Adding multilingual support
 
-So far, all our labels and comments are written in English, but there is no explicit indication of that in the vocabulary. To do so, RDF uses the concept of __language tag__: after a string, you can add a tag (e.g. @en for english, or @es for spanish) to hint its language.
+So far all our labels and comments are written in English, yet there is no explicit indication of that in the vocabulary. To do so, RDF uses the concept of __language tag__: after a string, you can add a tag (e.g. @en for English, or @es for Spanish) to stipulate its language.
 
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
@@ -308,7 +308,7 @@ obelisk:heigth a owl:DataProperty ;
     rdfs:range xsd:float.
 ```
 
-And why stop there? [Cleopatra](https://cleopatra.solid.community/profile/card#me) and [Caesar](https://jcaesar.solid.community/profile/card#me) want their vocabulary to be reused through the whole Roman empire, so they decide to translate the labels and comments to italian.
+And why stop there? [Cleopatra](https://cleopatra.solid.community/profile/card#me) and [Caesar](https://jcaesar.solid.community/profile/card#me) want their vocabulary to be reused throughout the entire Roman empire, so they decide to also provide Italian translations for their labels and comments.
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -357,7 +357,7 @@ obelisk:heigth a owl:DataProperty ;
 
 ## Adding some metadata
 
-The finishing touch to this vocabulary is to add some metadata, so that people who find it will have a global description before going through its details. We already decided that the IRI of the vocabulary was `http://w3id.org/obelisk/ns/`, so this is the identifier we are going to use in RDF to say stuff about the vocabulary. In linked-data talk, a vocabulary is called an [`owl:Ontology`](http://www.w3.org/2002/07/owl#Ontology), so the first thing to say is:
+The finishing touch to this vocabulary is to add some metadata, so that people who find it will have a global description before going through its details. We already decided that the IRI of the vocabulary would be `http://w3id.org/obelisk/ns/`, so this is the identifier we are going to use in RDF to say stuff about the vocabulary. In Linked Data terminology a vocabulary is called an [`owl:Ontology`](http://www.w3.org/2002/07/owl#Ontology), so the first thing to say is:
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -378,7 +378,7 @@ obelisk:Obelisk a rdfs:Class ;
 
 ### Adding some description
 
-like we described each term with human-friendly language, we will add a title ([`dcterms:title`](http://purl.org/dc/terms/title)) and a description ([`dcterms:description`](http://purl.org/dc/terms/description)) to our vocabulary. To make it easier to reuse, we can also indicate a preferred prefix ([`vann:preferredNamespacePrefix`](http://purl.org/vocab/vann/preferredNamespacePrefix)) and a preferred IRI, since multiple IRI may point to the same vocabulary ([`vann:preferredNamespaceURI`](http://purl.org/vocab/vann/preferredNamespaceURI)).
+Much like we described each term with human-friendly labels and comments, we can add a title ([`dcterms:title`](http://purl.org/dc/terms/title)) and a description ([`dcterms:description`](http://purl.org/dc/terms/description)) to our vocabulary. To make it easier to reuse, we can also indicate a preferred prefix ([`vann:preferredNamespacePrefix`](http://purl.org/vocab/vann/preferredNamespacePrefix)) and a preferred IRI ([`vann:preferredNamespaceURI`](http://purl.org/vocab/vann/preferredNamespaceURI)) (since multiple IRIs may point to the same vocabulary).
 ```turtle
 @prefix obelisk: <http://w3id.org/obelisk/ns/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -443,14 +443,14 @@ obelisk:Obelisk a rdfs:Class ;
 # ...
 ```
 
-### Versionning the vocabulary
+### Versioning the vocabulary
 
-A vocabulary may change over time, and it is helpful to give version information. Details about versionning a vocabulary are given later in the [vocabulary publication tutorial](4.1-publish-rdf#iri), but we can add the basic information here:
+A vocabulary may change over time, and so it is helpful to also provide some explicit version information. Details about versioning a vocabulary are given later in the [vocabulary publication tutorial](4.1-publish-rdf#iri), but we can add some basic information here, e.g.:
 - a version number ([`owl:versionInfo`](http://www.w3.org/2002/07/owl#versionInfo))
 - an initial publication date ([`dcterms:issued`](http://purl.org/dc/terms/issued))
 - a version release date ([`dcterms:modified`](http://purl.org/dc/terms/modified))
 
-This last modification yields a vocabulary in good shape to be used to describe data!
+This last modification yields a vocabulary in good shape to be used to describe our data:
 ```turtle
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .


### PR DESCRIPTION
Lots of small suggestions and typo fixes. One thing I'd question is the inclusion of rdfs:range and rdfs:domain though (as they are conceptually complex and abstract, and I rarely use them at all (as they tend to be very restrictive (hence Schema.org defining the much looser 'schema:rangeIncludes' and 'schema:domainIncludes'))).
Overall I think this is really good, but my sense is that it's still too 'advanced' (and long-winded) for a basic introduction to RDF and Turtle. I think it could be split into two maybe, i.e. a really minimal 'intro', and then a 'slightly more advanced' section.