### PR TITLE
Add missing items from Jeff's page

### DIFF
--- a/_posts/for-developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/for-developers/apps/tools/2019-01-01-00_overview.md
@@ -12,19 +12,33 @@ exclude: true
 ## Javascript
 
 - [Solid React SDK](https://github.com/inrupt/solid-react-sdk)
+- [Solid Angular SDK](https://github.com/inrupt/generator-solid-angular)
 - [Solid auth client](https://github.com/solid/solid-auth-client)
 - [Solid UI](https://github.com/solid/solid-ui), and the associated [Solid panes](https://github.com/solid/solid-panes)
 - [Mashlib](https://github.com/solid/mashlib), for data mashup
 - [LDflex for Solid](https://github.com/solid/query-ldflex)
+- [Solid Cli](https://github.com/solid/solid-cli), a utility to facilitate command-line interaction with Solid servers
+- [Solid Auth Cli](https://github.com/jeff-zucker/solid-auth-cli), a node/command-line Solid client with persistent login
+- [Solid File Client](https://github.com/jeff-zucker/solid-file-client), create and manage files and folders in Solid Pods
+- [Solid-Rest](https://github.com/jeff-zucker/solid-rest)
+- [Solid-Local-Pod-Manager](https://github.com/otto-aa/solid-local-pod-manager)
+- [Solid React Components](https://github.com/solid/react-components)
+- [GraphQL-LD Solid React Components](https://github.com/rubensworks/solid-react-graphql-ld.js), a GraphQL-LD engine with Solid authentication
 
 # RDF libraries
 
 ## Javascript
+(several of these will use Solid authentication from solid-auth-client if present)
 
 - [Tripledoc](https://vincenttunru.gitlab.io/tripledoc/): A library for easy manipulation on RDF
 - [rdflib](https://github.com/linkeddata/rdflib.js/): A library for advanced manipulation of RDF
 - [LDFlex](https://rubenverborgh.github.io/LDflex/): A library for making RDF querying easy
 - [rdf-ext](https://github.com/rdf-ext/rdf-ext): An implementation of RDFJS specifications
+- [Sparql Fiddle](https://github.com/jeff-zucker/sparql-fiddle), a JavaScript SPARQL API for Solid Pods
+- [Comunica](https://github.com/comunica/comunica), a highly modular and flexible meta query engine for the Web
+- [GraphQL-LD for Solid](https://github.com/rubensworks/graphql-ld-comunica-solid.js), a GraphQL-LD engine
+- [RDF-Easy](https://github.com/jeff-zucker/rdf-easy)
+- [Soukai-solid](https://github.com/NoelDeMartin/soukai-solid)
 
 ## Python
 


### PR DESCRIPTION
Only copied over the ones from the 'Auth & File Access Tools', 'RDF Creating, Parsing, Querying Tools', and 'Libraries and Toolkits for React' sections, not the 'Libraries and Toolkits for the Panes UI', 'Additional Tools (not specific to Solid)', 'Wishlist and In-Development Tools', 'Archived/Outdated Tools & Libraries' and 'Low-level Libraries' sections from https://github.com/jeff-zucker/solid-libraries/blob/master/README.md

Also added the angular SDK since that was missing.