### PR TITLE
Fix inaccurate tagline

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -8,7 +8,7 @@ permalink: /
   <div class="title-banner">
     <h1 class="title">Solid</h1>
     <div class="subtitle">
-      A standard that makes the web work for you
+      An ecosystem that makes the Web work for you
     </div>
     <a href="{{site.baseurl}}/get-started" class="learn-btn">Get started</a>
       <a href="#what-is-solid" class="learn-more-link">


### PR DESCRIPTION
The current tagline is

> A standard that makes the web work for you 

However, this is factually inaccurate. Solid is by no means "a standard".

If anything, it is a collection of specifications. But this neglects the majority of the work carried out by companies and volunteers, which involves implementations. Hence, I suggest "ecosystem".

It is important this fix is made soon; the current text spreads misinformation. While "ecosystem" might not be the best tagline, at least it is factually correct, and can be replaced later.