### PR TITLE
Re-order cards on Get Started page

### DIFF
--- a/pages/get-started.md
+++ b/pages/get-started.md
@@ -6,23 +6,6 @@ permalink: /get-started
 
 <div class="cards row around">
   <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
-    <a href="{{site.baseUrl}}/for-developers" class="card">
-      <div class="card-header">
-        <img
-          src="{{site.baseurl}}/assets/img/fontawesome-free-5.11.2-web/svgs/solid/code.svg"
-          alt=""
-          class="icon"
-        />
-        <span class="card-title">I'm a developer</span>
-      </div>
-      <div class="card-body">
-        <p>
-          Start building Solid apps or running your own Pod.
-        </p>
-      </div>
-    </a>
-  </div>
-  <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
     <a href="{{site.baseUrl}}/use-solid" class="card">
       <div class="card-header">
         <img
@@ -35,6 +18,23 @@ permalink: /get-started
       <div class="card-body">
         <p>
           Start using Solid apps that let you pick your own Pod.
+        </p>
+      </div>
+    </a>
+  </div>
+  <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+    <a href="{{site.baseUrl}}/for-developers" class="card">
+      <div class="card-header">
+        <img
+          src="{{site.baseurl}}/assets/img/fontawesome-free-5.11.2-web/svgs/solid/code.svg"
+          alt=""
+          class="icon"
+        />
+        <span class="card-title">I'm a developer</span>
+      </div>
+      <div class="card-body">
+        <p>
+          Start building Solid apps or running your own Pod.
         </p>
       </div>
     </a>


### PR DESCRIPTION
They now align with the order of the menu items in the navigations,
i.e. "I want to use Solid" first, "I'm a developer" second, and "I
represent..." third.

Since #232 the Get Started page is no longer reachable, but if we were to enable it again, would be good to use a consistent order.