### PR TITLE
change recursive option of chmod to upper case

### DIFF
--- a/for-developers/pod-server.html
+++ b/for-developers/pod-server.html
@@ -133,7 +133,7 @@
 <code class="highlighter-rouge">--agree-tos \</code><br />
 <code class="highlighter-rouge">-d example.org -d *.example.org</code><br />
 //now DNS-challenge<br />
-<code class="highlighter-rouge">$ chmod -r 777 /etc/letsencrypt/live/</code><br /></li>
+<code class="highlighter-rouge">$ chmod -R 777 /etc/letsencrypt/live/</code><br /></li>
 </ul>
 
 <h2 id="configure-a-reverse-proxy">Configure a reverse proxy</h2>


### PR DESCRIPTION
change recursive option of chmod command for letsencrypt directory to upper case
source: manpage chmod
this was a minor but important typo